### PR TITLE
Updates to be compatible with AutoMapper 4.2 changes

### DIFF
--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/App.config
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/App.config
@@ -14,4 +14,4 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
     </providers>
   </entityFramework>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutoMapper.Collection.EntityFramework</RootNamespace>
     <AssemblyName>AutoMapper.Collection.EntityFramework</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.0.4.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.0.4\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.4.2.0-ci-1050\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
@@ -77,6 +77,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
@@ -68,6 +68,7 @@
     <ProjectReference Include="..\AutoMapper.Collection\AutoMapper.Collection.csproj">
       <Project>{37ad667a-8080-476c-88fd-20310ac7caf3}</Project>
       <Name>AutoMapper.Collection</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/AutoMapper.Collection.EntityFramework.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.2.0-ci-1050\lib\net45\AutoMapper.dll</HintPath>
+      <HintPath>..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Extensions.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Extensions.cs
@@ -15,6 +15,7 @@ namespace AutoMapper.EntityFramework
         /// <typeparam name="TSource">Source table type to be updated</typeparam>
         /// <param name="source">DbSet to be updated</param>
         /// <returns>Persistance object to Update or Remove data</returns>
+        [Obsolete("Use version that passes instance of IMapper")]
         public static IPersistance Persist<TSource>(this DbSet<TSource> source)
             where TSource : class
         {

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Extensions.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Extensions.cs
@@ -14,10 +14,10 @@ namespace AutoMapper.EntityFramework
         /// <typeparam name="TSource">Source table type to be updated</typeparam>
         /// <param name="source">DbSet to be updated</param>
         /// <returns>Persistance object to Update or Remove data</returns>
-        public static IPersistance Persist<TSource>(this DbSet<TSource> source)
+        public static IPersistance Persist<TSource>(this DbSet<TSource> source, IMapper mapper)
             where TSource : class
         {
-            return new Persistance<TSource>(source, Mapper.Engine);
+            return new Persistance<TSource>(source, mapper);
         }
 
         /// <summary>

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Extensions.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Extensions.cs
@@ -10,9 +10,23 @@ namespace AutoMapper.EntityFramework
     {
         /// <summary>
         /// Create a persistance object for the <see cref="T:System.Data.Entity.DbSet`1"/> to have data persisted or removed from
+        /// Uses static API's Mapper for finding TypeMap between classes
         /// </summary>
         /// <typeparam name="TSource">Source table type to be updated</typeparam>
         /// <param name="source">DbSet to be updated</param>
+        /// <returns>Persistance object to Update or Remove data</returns>
+        public static IPersistance Persist<TSource>(this DbSet<TSource> source)
+            where TSource : class
+        {
+            return new Persistance<TSource>(source, null);
+        }
+
+        /// <summary>
+        /// Create a persistance object for the <see cref="T:System.Data.Entity.DbSet`1"/> to have data persisted or removed from
+        /// </summary>
+        /// <typeparam name="TSource">Source table type to be updated</typeparam>
+        /// <param name="source">DbSet to be updated</param>
+        /// <param name="mapper">IMapper used to find TypeMap between classes</param>
         /// <returns>Persistance object to Update or Remove data</returns>
         public static IPersistance Persist<TSource>(this DbSet<TSource> source, IMapper mapper)
             where TSource : class

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/GenerateEntityFrameworkPrimaryKeyEquivilentExpressions.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/GenerateEntityFrameworkPrimaryKeyEquivilentExpressions.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Entity.Infrastructure;
+﻿using System;
+using System.Data.Entity.Infrastructure;
 using AutoMapper.EquivilencyExpression;
 
 namespace AutoMapper.EntityFramework
@@ -23,6 +24,7 @@ namespace AutoMapper.EntityFramework
         /// Generate EquivilencyExpressions based on EnityFramework's primary key
         /// Uses static API's Mapper for finding TypeMap between classes
         /// </summary>
+        [Obsolete("Use version that passes instance of IMapper")]
         public GenerateEntityFrameworkPrimaryKeyEquivilentExpressions()
            : base(new GenerateEntityFrameworkPrimaryKeyPropertyMaps<TDatabaseContext>(null))
         {

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/GenerateEntityFrameworkPrimaryKeyEquivilentExpressions.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/GenerateEntityFrameworkPrimaryKeyEquivilentExpressions.cs
@@ -8,10 +8,23 @@ namespace AutoMapper.EntityFramework
     /// </summary>
     /// <typeparam name="TDatabaseContext">Database Context</typeparam>
     public class GenerateEntityFrameworkPrimaryKeyEquivilentExpressions<TDatabaseContext> : GenerateEquivilentExpressionsBasedOnGeneratePropertyMaps
-        where TDatabaseContext : IObjectContextAdapter, new() 
+        where TDatabaseContext : IObjectContextAdapter, new()
     {
+        /// <summary>
+        /// Generate EquivilencyExpressions based on EnityFramework's primary key
+        /// </summary>
+        /// <param name="mapper">IMapper used to find TypeMap between classes</param>
+        public GenerateEntityFrameworkPrimaryKeyEquivilentExpressions(IMapper mapper)
+            : base(new GenerateEntityFrameworkPrimaryKeyPropertyMaps<TDatabaseContext>(mapper))
+        {
+        }
+
+        /// <summary>
+        /// Generate EquivilencyExpressions based on EnityFramework's primary key
+        /// Uses static API's Mapper for finding TypeMap between classes
+        /// </summary>
         public GenerateEntityFrameworkPrimaryKeyEquivilentExpressions()
-            : base(new GenerateEntityFrameworkPrimaryKeyPropertyMaps<TDatabaseContext>())
+           : base(new GenerateEntityFrameworkPrimaryKeyPropertyMaps<TDatabaseContext>(null))
         {
         }
     }

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/GenerateEntityFrameworkPrimaryKeyPropertyMatches.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/GenerateEntityFrameworkPrimaryKeyPropertyMatches.cs
@@ -12,13 +12,22 @@ namespace AutoMapper.EntityFramework
     public class GenerateEntityFrameworkPrimaryKeyPropertyMaps<TDatabaseContext> : IGeneratePropertyMaps
         where TDatabaseContext : IObjectContextAdapter, new()
     {
+        private readonly IMapper _mapper;
+
         private readonly TDatabaseContext _context = new TDatabaseContext();
         private readonly MethodInfo _createObjectSetMethodInfo = typeof(ObjectContext).GetMethod("CreateObjectSet", Type.EmptyTypes);
 
+        public GenerateEntityFrameworkPrimaryKeyPropertyMaps(IMapper mapper)
+        {
+            _mapper = mapper;
+        }
+
         public IEnumerable<PropertyMap> GeneratePropertyMaps(Type srcType, Type destType)
         {
-            var mapper = Mapper.FindTypeMapFor(srcType, destType);
-            var propertyMaps = mapper.GetPropertyMaps();
+            var typeMap = _mapper == null
+                ? (Mapper.Configuration as IConfigurationProvider).ResolveTypeMap(srcType, destType)
+                : _mapper.ConfigurationProvider.ResolveTypeMap(srcType, destType);
+            var propertyMaps = typeMap.GetPropertyMaps();
             var createObjectSetMethod = _createObjectSetMethodInfo.MakeGenericMethod(destType);
             dynamic objectSet = createObjectSetMethod.Invoke(_context.ObjectContext, null);
 

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Persistance.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Persistance.cs
@@ -9,18 +9,18 @@ namespace AutoMapper.EntityFramework
         where TTo : class
     {
         private readonly DbSet<TTo> _sourceSet;
-        private readonly IMappingEngine _mappingEngine;
+        private readonly IMapper _mapper;
 
-        public Persistance(DbSet<TTo> sourceSet, IMappingEngine mappingEngine)
+        public Persistance(DbSet<TTo> sourceSet, IMapper mapper)
         {
-            _mappingEngine = mappingEngine;
             _sourceSet = sourceSet;
+            _mapper = mapper;
         }
 
         public void InsertOrUpdate<TFrom>(TFrom from)
             where TFrom : class
         {
-            var equivExpr = Mapper.Map<TFrom,Expression<Func<TTo, bool>>>(from);
+            var equivExpr = _mapper.Map<TFrom,Expression<Func<TTo, bool>>>(from);
             if (equivExpr == null)
                 return;
 
@@ -31,13 +31,13 @@ namespace AutoMapper.EntityFramework
                 to = _sourceSet.Create<TTo>();
                 _sourceSet.Add(to);
             }
-            Mapper.Map(from,to);
+            _mapper.Map(from,to);
         }
 
         public void Remove<TFrom>(TFrom from)
             where TFrom : class
         {
-            var equivExpr = Mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from);
+            var equivExpr = _mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from);
             if (equivExpr == null)
                 return;
             var to = _sourceSet.FirstOrDefault(equivExpr);

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Persistance.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Persistance.cs
@@ -20,7 +20,9 @@ namespace AutoMapper.EntityFramework
         public void InsertOrUpdate<TFrom>(TFrom from)
             where TFrom : class
         {
-            var equivExpr = _mapper.Map<TFrom,Expression<Func<TTo, bool>>>(from);
+            var equivExpr = _mapper == null
+                ? Mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from)
+                : _mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from);
             if (equivExpr == null)
                 return;
 
@@ -31,13 +33,18 @@ namespace AutoMapper.EntityFramework
                 to = _sourceSet.Create<TTo>();
                 _sourceSet.Add(to);
             }
-            _mapper.Map(from,to);
+            if (_mapper == null)
+                Mapper.Map(from, to);
+            else
+                _mapper.Map(from,to);
         }
 
         public void Remove<TFrom>(TFrom from)
             where TFrom : class
         {
-            var equivExpr = _mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from);
+            var equivExpr = _mapper == null
+                ? Mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from)
+                : _mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from);
             if (equivExpr == null)
                 return;
             var to = _sourceSet.FirstOrDefault(equivExpr);

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Properties/AssemblyInfo.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/packages.config
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.0-ci-1050" targetFramework="net45" />
+  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
 </packages>

--- a/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/packages.config
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.EntityFramework/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.0.4" targetFramework="net451" requireReinstallation="true" />
-  <package id="EntityFramework" version="6.1.3" targetFramework="net451" requireReinstallation="true" />
+  <package id="AutoMapper" version="4.2.0-ci-1050" targetFramework="net45" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
 </packages>

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/AutoMapper.Collection.LinqToSQL.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/AutoMapper.Collection.LinqToSQL.csproj
@@ -58,6 +58,7 @@
     <ProjectReference Include="..\AutoMapper.Collection\AutoMapper.Collection.csproj">
       <Project>{37ad667a-8080-476c-88fd-20310ac7caf3}</Project>
       <Name>AutoMapper.Collection</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/AutoMapper.Collection.LinqToSQL.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/AutoMapper.Collection.LinqToSQL.csproj
@@ -34,9 +34,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.2.0-ci-1050\lib\net45\AutoMapper.dll</HintPath>
+      <HintPath>..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/AutoMapper.Collection.LinqToSQL.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/AutoMapper.Collection.LinqToSQL.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutoMapper.Collection.LinqToSQL</RootNamespace>
     <AssemblyName>AutoMapper.Collection.LinqToSQL</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,32 +30,17 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.0.4.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.0.4\lib\net40\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.4.2.0-ci-1050\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.Linq" />
-    <Reference Include="System.IO, Version=2.6.9.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Runtime, Version=2.6.9.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Threading.Tasks, Version=2.6.9.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <Reference Include="System.Data.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GetLinqToSQLPrimaryKeyExpression.cs" />

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/GetLinqToSQLPrimaryKeyExpression.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/GetLinqToSQLPrimaryKeyExpression.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper.EquivilencyExpression;
+﻿using System;
+using AutoMapper.EquivilencyExpression;
 
 namespace AutoMapper.Collection.LinqToSQL
 {
@@ -16,6 +17,7 @@ namespace AutoMapper.Collection.LinqToSQL
         /// <summary>
         /// Generate EquivilencyExpressions based on LinqToSQL's primary key
         /// Uses static API's Mapper for finding TypeMap between classes
+        [Obsolete("Use version that passes instance of IMapper")]
         /// </summary>
         public GetLinqToSQLPrimaryKeyExpression()
            : base(new GetLinqToSQLPrimaryKeyProperties(null))

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/GetLinqToSQLPrimaryKeyExpression.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/GetLinqToSQLPrimaryKeyExpression.cs
@@ -4,8 +4,21 @@ namespace AutoMapper.Collection.LinqToSQL
 {
     public class GetLinqToSQLPrimaryKeyExpression : GenerateEquivilentExpressionsBasedOnGeneratePropertyMaps
     {
+        /// <summary>
+        /// Generate EquivilencyExpressions based on LinqToSQL's primary key
+        /// </summary>
+        /// <param name="mapper">IMapper used to find TypeMap between classes</param>
+        public GetLinqToSQLPrimaryKeyExpression(IMapper mapper)
+            : base(new GetLinqToSQLPrimaryKeyProperties(mapper))
+        {
+        }
+
+        /// <summary>
+        /// Generate EquivilencyExpressions based on LinqToSQL's primary key
+        /// Uses static API's Mapper for finding TypeMap between classes
+        /// </summary>
         public GetLinqToSQLPrimaryKeyExpression()
-            : base(new GetLinqToSQLPrimaryKeyProperties())
+           : base(new GetLinqToSQLPrimaryKeyProperties(null))
         {
         }
     }

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/GetLinqToSQLPrimaryKeyProperties.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/GetLinqToSQLPrimaryKeyProperties.cs
@@ -9,10 +9,19 @@ namespace AutoMapper.Collection.LinqToSQL
 {
     public class GetLinqToSQLPrimaryKeyProperties : IGeneratePropertyMaps
     {
+        private readonly IMapper _mapper;
+
+        public GetLinqToSQLPrimaryKeyProperties(IMapper mapper)
+        {
+            _mapper = mapper;
+        }
+
         public IEnumerable<PropertyMap> GeneratePropertyMaps(Type srcType, Type destType)
         {
-            var mapper = (Mapper.Configuration as IConfigurationProvider).ResolveTypeMap(srcType, destType);
-            var propertyMaps = mapper.GetPropertyMaps();
+            var typeMap = _mapper == null
+                ? (Mapper.Configuration as IConfigurationProvider).ResolveTypeMap(srcType, destType)
+                : _mapper.ConfigurationProvider.ResolveTypeMap(srcType, destType);
+            var propertyMaps = typeMap.GetPropertyMaps();
 
             var primaryKeyPropertyMatches = destType.GetProperties().Where(IsPrimaryKey).Select(m => propertyMaps.FirstOrDefault(p => p.DestinationProperty.Name == m.Name)).ToList();
 

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/Persistance.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/Persistance.cs
@@ -25,7 +25,9 @@ namespace AutoMapper.Collection.LinqToSQL
 
         public void InsertOrUpdate(Type type, object from)
         {
-            var equivExpr = _mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>;
+            var equivExpr = _mapper == null
+                ? Mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>
+                : _mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>;
             if (equivExpr == null)
                 return;
 
@@ -36,13 +38,18 @@ namespace AutoMapper.Collection.LinqToSQL
                 to = Activator.CreateInstance<TTo>();
                 _sourceSet.InsertOnSubmit(to);
             }
-            _mapper.Map(from, to);
+            if (_mapper == null)
+                Mapper.Map(from, to);
+            else
+                _mapper.Map(from, to);
         }
 
         public void Remove<TFrom>(TFrom from)
             where TFrom : class
         {
-            var equivExpr = _mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from);
+            var equivExpr = _mapper == null
+                ? Mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from)
+                : _mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from);
             if (equivExpr == null)
                 return;
             var to = _sourceSet.FirstOrDefault(equivExpr);

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/Persistance.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/Persistance.cs
@@ -9,11 +9,11 @@ namespace AutoMapper.Collection.LinqToSQL
         where TTo : class
     {
         private readonly Table<TTo> _sourceSet;
-        private readonly IMappingEngine _mappingEngine;
+        private readonly IMapper _mapper;
 
-        public Persistance(Table<TTo> sourceSet, IMappingEngine mappingEngine)
+        public Persistance(Table<TTo> sourceSet, IMapper mapper)
         {
-            _mappingEngine = mappingEngine;
+            _mapper = mapper;
             _sourceSet = sourceSet;
         }
 
@@ -25,7 +25,7 @@ namespace AutoMapper.Collection.LinqToSQL
 
         public void InsertOrUpdate(Type type, object from)
         {
-            var equivExpr = Mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>;
+            var equivExpr = _mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>;
             if (equivExpr == null)
                 return;
 
@@ -36,13 +36,13 @@ namespace AutoMapper.Collection.LinqToSQL
                 to = Activator.CreateInstance<TTo>();
                 _sourceSet.InsertOnSubmit(to);
             }
-            _mappingEngine.Map(from, to);
+            _mapper.Map(from, to);
         }
 
         public void Remove<TFrom>(TFrom from)
             where TFrom : class
         {
-            var equivExpr = Mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from);
+            var equivExpr = _mapper.Map<TFrom, Expression<Func<TTo, bool>>>(from);
             if (equivExpr == null)
                 return;
             var to = _sourceSet.FirstOrDefault(equivExpr);

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/PersistanceExtensions.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/PersistanceExtensions.cs
@@ -2,13 +2,32 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.Linq;
-using System.Reflection;
 using AutoMapper.QueryableExtensions.Impl;
 
 namespace AutoMapper.Collection.LinqToSQL
 {
     public static class PersistanceExtensions
     {
+        /// <summary>
+        /// Create a persistance object for the <see cref="T:System.Data.Entity.DbSet`1"/> to have data persisted or removed from
+        /// Uses static API's Mapper for finding TypeMap between classes
+        /// </summary>
+        /// <typeparam name="TSource">Source table type to be updated</typeparam>
+        /// <param name="source">Table to be updated</param>
+        /// <returns>Persistance object to Update or Remove data</returns>
+        public static IPersistance Persist<TSource>(this Table<TSource> source)
+            where TSource : class
+        {
+            return new Persistance<TSource>(source, null);
+        }
+
+        /// <summary>
+        /// Create a persistance object for the <see cref="T:System.Data.Entity.DbSet`1"/> to have data persisted or removed from
+        /// </summary>
+        /// <typeparam name="TSource">Source table type to be updated</typeparam>
+        /// <param name="source">Table to be updated</param>
+        /// <param name="mapper">IMapper used to find TypeMap between classes</param>
+        /// <returns>Persistance object to Update or Remove data</returns>
         public static IPersistance Persist<TSource>(this Table<TSource> source, IMapper mapper)
             where TSource : class
         {

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/PersistanceExtensions.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/PersistanceExtensions.cs
@@ -9,10 +9,10 @@ namespace AutoMapper.Collection.LinqToSQL
 {
     public static class PersistanceExtensions
     {
-        public static IPersistance Persist<TSource>(this Table<TSource> source)
+        public static IPersistance Persist<TSource>(this Table<TSource> source, IMapper mapper)
             where TSource : class
         {
-            return new Persistance<TSource>(source, Mapper.Engine);
+            return new Persistance<TSource>(source, mapper);
         }
 
         public static IEnumerable For<TSource>(this IQueryDataSourceInjection<TSource> source, Type destType)

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/PersistanceExtensions.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/PersistanceExtensions.cs
@@ -15,6 +15,7 @@ namespace AutoMapper.Collection.LinqToSQL
         /// <typeparam name="TSource">Source table type to be updated</typeparam>
         /// <param name="source">Table to be updated</param>
         /// <returns>Persistance object to Update or Remove data</returns>
+        [Obsolete("Use version that passes instance of IMapper")]
         public static IPersistance Persist<TSource>(this Table<TSource> source)
             where TSource : class
         {

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/Properties/AssemblyInfo.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/packages.config
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.0.4" targetFramework="net4" />
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net4" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net4" />
+  <package id="AutoMapper" version="4.2.0-ci-1050" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
 </packages>

--- a/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/packages.config
+++ b/src/AutoMapper.Collection/AutoMapper.Collection.LinqToSQL/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.0-ci-1050" targetFramework="net45" />
+  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
 </packages>

--- a/src/AutoMapper.Collection/AutoMapper.Collection/AutoMapper.Collection.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/AutoMapper.Collection.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutoMapper.Collection</RootNamespace>
     <AssemblyName>AutoMapper.Collection</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.0.4.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.0.4\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.4.2.0-ci-1050\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CollectionProfile.cs" />
+    <Compile Include="ReflectionHelper.cs" />
     <Compile Include="Mappers\ObjectToEquivalencyExpressionByEquivalencyExistingMapper.cs" />
     <Compile Include="Equivilency Expression\CustomExpressionVisitor.cs" />
     <Compile Include="Equivilency Expression\EquivilentExpression.cs" />
@@ -63,9 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Equivilency Expression\packages.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
@@ -74,6 +73,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoMapper.Collection/AutoMapper.Collection/AutoMapper.Collection.csproj
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/AutoMapper.Collection.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.2.0-ci-1050\lib\net45\AutoMapper.dll</HintPath>
+      <HintPath>..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/AutoMapper.Collection/AutoMapper.Collection/Equivilency Expression/EquivilentExpression.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/Equivilency Expression/EquivilentExpression.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
-using AutoMapper.Impl;
-using AutoMapper.Internal;
 
 namespace AutoMapper.EquivilencyExpression
 {
@@ -48,7 +46,7 @@ namespace AutoMapper.EquivilencyExpression
             return GetSourceOnlyExpresison(source as TSource);
         }
 
-        internal Expression GetSourceOnlyExpresison<TSource>(TSource source)
+        internal Expression GetSourceOnlyExpresison(TSource source)
         {
             var expression = new ParametersToConstantVisitor<TSource>(source).Visit(_equivilentExpression) as LambdaExpression;
             return Expression.Lambda(expression.Body, _equivilentExpression.Parameters[1]);

--- a/src/AutoMapper.Collection/AutoMapper.Collection/Equivilency Expression/EquivilentExpressions.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/Equivilency Expression/EquivilentExpressions.cs
@@ -13,17 +13,12 @@ namespace AutoMapper.EquivilencyExpression
         /// <summary>
         /// Equality List for Generating Equality Comparisons between two types
         /// </summary>
-        public static ICollection<IGenerateEquivilentExpressions> GenerateEquality
-        {
-            get { return GenerateEquivilentExpressions; }
-        }
+        public static ICollection<IGenerateEquivilentExpressions> GenerateEquality => GenerateEquivilentExpressions;
 
         internal static IEquivilentExpression GetEquivilentExpression(Type sourceType, Type destinationType)
         {
             var generate = GenerateEquality.FirstOrDefault(g => g.CanGenerateEquivilentExpression(sourceType, destinationType));
-            if (generate == null)
-                return null;
-            return generate.GeneratEquivilentExpression(sourceType, destinationType);
+            return generate?.GeneratEquivilentExpression(sourceType, destinationType);
         }
 
         /// <summary>

--- a/src/AutoMapper.Collection/AutoMapper.Collection/Mappers/ObjectToEquivalencyExpressionByEquivalencyExistingMapper.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/Mappers/ObjectToEquivalencyExpressionByEquivalencyExistingMapper.cs
@@ -4,19 +4,19 @@ namespace AutoMapper.Mappers
 {
     public class ObjectToEquivalencyExpressionByEquivalencyExistingMapper : IObjectMapper
     {
-        public object Map(ResolutionContext context, IMappingEngineRunner mapper)
+        public object Map(ResolutionContext context)
         {
             var destExpressArgType = context.DestinationType.GetSinglePredicateExpressionArgumentType();
             var toSourceExpression = EquivilentExpressions.GetEquivilentExpression(context.SourceType, destExpressArgType) as IToSingleSourceEquivalentExpression;
             return toSourceExpression.ToSingleSourceExpression(context.SourceValue);
         }
 
-        public bool IsMatch(ResolutionContext context)
+        public bool IsMatch(TypePair typePair)
         {
-            var destExpressArgType = context.DestinationType.GetSinglePredicateExpressionArgumentType();
+            var destExpressArgType = typePair.DestinationType.GetSinglePredicateExpressionArgumentType();
             if (destExpressArgType == null)
                 return false;
-            var expression = EquivilentExpressions.GetEquivilentExpression(context.SourceType, destExpressArgType);
+            var expression = EquivilentExpressions.GetEquivilentExpression(typePair.SourceType, destExpressArgType);
             return expression is IToSingleSourceEquivalentExpression;
         }
     }

--- a/src/AutoMapper.Collection/AutoMapper.Collection/Properties/AssemblyInfo.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.2.0")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/src/AutoMapper.Collection/AutoMapper.Collection/ReflectionHelper.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/ReflectionHelper.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using AutoMapper.Internal;
+
+namespace AutoMapper.EquivilencyExpression
+{
+    internal static class ReflectionHelper
+    {
+        public static IMemberGetter ToMemberGetter(this MemberInfo accessorCandidate)
+        {
+            if (accessorCandidate == null)
+                return null;
+
+            if (accessorCandidate is PropertyInfo)
+                return new PropertyGetter((PropertyInfo)accessorCandidate);
+
+            if (accessorCandidate is FieldInfo)
+                return new FieldGetter((FieldInfo)accessorCandidate);
+
+            if (accessorCandidate is MethodInfo)
+                return new MethodGetter((MethodInfo)accessorCandidate);
+
+            return null;
+        }
+    }
+}

--- a/src/AutoMapper.Collection/AutoMapper.Collection/packages.config
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.0.4" targetFramework="net451" requireReinstallation="true" />
+  <package id="AutoMapper" version="4.2.0-ci-1050" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
 </packages>

--- a/src/AutoMapper.Collection/AutoMapper.Collection/packages.config
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.0-ci-1050" targetFramework="net45" />
+  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updated classes that inherit from IObjectMapper to change in IsMatch.

Added non-static API calls to IMapper for Persist and LinqToSQL and EntityFramework Equivalent Expression generation classes.  Still have original static API calls as well.

@jbogard Any thoughts on changes to IMapper for Equivalent Expressions?
`EquivilentExpressions.GenerateEquality.Add(new GenerateEntityFrameworkPrimaryKeyEquivilentExpressions<TDataContext>(mapper));` gets called but you have to do it outside of the mapper configuration, because the IMapper is the only place that exposes IConfigurationProvider to call `FindTypeMap`.

There shouldn't be any order of operations problems, but as it stands right now it doesn't follow flow of 5.0, so it can't be easily integrated into AutoMapper as it is now.