### PR TITLE
expression.Compile should not be executed for each item

### DIFF
--- a/src/AutoMapper.Collection/AutoMapper.Collection/Equivilency Expression/EquivilentExpression.cs
+++ b/src/AutoMapper.Collection/AutoMapper.Collection/Equivilency Expression/EquivilentExpression.cs
@@ -24,10 +24,12 @@ namespace AutoMapper.EquivilencyExpression
         where TDestination : class
     {
         private readonly Expression<Func<TSource, TDestination, bool>> _equivilentExpression;
+        private readonly Func<TSource, TDestination, bool> _equivilentExpressionFunc;
 
         public EquivilentExpression(Expression<Func<TSource,TDestination,bool>> equivilentExpression)
         {
             _equivilentExpression = equivilentExpression;
+            _equivilentExpressionFunc = equivilentExpression.Compile();
         }
 
         public bool IsEquivlent(object source, object destination)
@@ -36,7 +38,7 @@ namespace AutoMapper.EquivilencyExpression
                 throw new EquivilentExpressionNotOfTypeException(source.GetType(), typeof(TSource));
             if (!(destination is TDestination))
                 throw new EquivilentExpressionNotOfTypeException(destination.GetType(), typeof(TDestination));
-            return _equivilentExpression.Compile()(source as TSource, destination as TDestination);
+            return _equivilentExpressionFunc(source as TSource, destination as TDestination);
         }
 
         public Expression ToSingleSourceExpression(object source)


### PR DESCRIPTION
Compillation of expression is done in the IsEquivlent method, for each entity/object to match. This is huge degradation of performance. This is a fix for AutoMapper 4.2 version and exists already in master-branch.

Before change
![image](https://cloud.githubusercontent.com/assets/357589/18131386/e8e1989e-6f92-11e6-9d29-63fda5b21d47.png)

After change
![image](https://cloud.githubusercontent.com/assets/357589/18131396/f3b5ff12-6f92-11e6-8c28-c165848979c7.png)
